### PR TITLE
Reduce Alert Spam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,12 +1428,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "swat-accumulator"
+name = "swat-collector"
 version = "0.1.0"
 dependencies = [
  "chrono",
  "futures",
  "influxdb2",
+ "log",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "swat-accumulator"
+name = "swat-collector"
 version = "0.1.0"
 edition = "2021"
 
@@ -53,3 +53,5 @@ version = "0.4"
 
 [dependencies.futures]
 version = "0.3"
+[dependencies]
+log = "0.4.20"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY . /build
 RUN cargo build --release --locked
 
 FROM alpine:latest
-COPY --from=build-service /build/target/release/swat-accumulator /swat-accumulator
-ENTRYPOINT ["/swat-accumulator"]
-LABEL org.opencontainers.image.source=https://github.com/wisdom-oss/service-swat-accumulator
+COPY --from=build-service /build/target/release/swat-collector /swat-collector
+ENTRYPOINT ["/swat-collector"]
+LABEL org.opencontainers.image.source=https://github.com/wisdom-oss/service-swat-collector
 # TODO: when this should handle request, this needs an exposed port

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -41,7 +41,7 @@ impl Webhook {
     ) -> Result<(), WebhookExecuteError> {
         let mut embed = EmbedBuilder::new()
             .color(0x9E2C2C)
-            .description("Some errors occurred.\nWe notify again when everything is green again.");
+            .description("Some errors occurred.\nAs soon as all requests are successful again you will be notified.");
 
         for field in errors.iter().take(FIELD_COUNT).map(|(location, error)| {
             EmbedFieldBuilder::new(location.name, error.to_string()).build()

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -55,7 +55,7 @@ impl Webhook {
     pub async fn resolved(&self) -> Result<(), WebhookExecuteError> {
         let embed = EmbedBuilder::new()
             .color(0x57F287)
-            .description("Every request was successful.");
+            .description("All requests have been successful. Collector working as expected again.");
         self.execute_embed_webhook(embed.build()).await
     }
 

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -1,11 +1,14 @@
 use crate::locations::Location;
-use std::fmt::Display;
+use crate::HandleLocationError;
+
 use thiserror::Error;
 use twilight_http::client::Client as DiscordClient;
 use twilight_http::error::Error as HttpError;
+use twilight_model::channel::message::Embed;
 use twilight_model::id::marker::WebhookMarker;
 use twilight_model::id::Id;
-use twilight_util::builder::embed::{EmbedAuthorBuilder, EmbedBuilder};
+use twilight_util::builder::embed::{EmbedBuilder, EmbedFieldBuilder};
+use twilight_validate::embed::FIELD_COUNT;
 use twilight_validate::message::MessageValidationError;
 
 pub struct Webhook {
@@ -32,17 +35,31 @@ impl Webhook {
         }
     }
 
-    pub async fn execute(
+    pub async fn alert(
         &self,
-        location: &Location,
-        content: impl Display,
+        errors: &[(&Location, HandleLocationError)],
     ) -> Result<(), WebhookExecuteError> {
-        let embed = EmbedBuilder::new()
-            .color(0x9e2c2c)
-            .author(EmbedAuthorBuilder::new(location.name).build())
-            .description(content.to_string())
-            .build();
+        let mut embed = EmbedBuilder::new()
+            .color(0x9E2C2C)
+            .description("Some errors occurred.\nWe notify again when everything is green again.");
 
+        for field in errors.iter().take(FIELD_COUNT).map(|(location, error)| {
+            EmbedFieldBuilder::new(location.name, error.to_string()).build()
+        }) {
+            embed = embed.field(field);
+        }
+
+        self.execute_embed_webhook(embed.build()).await
+    }
+
+    pub async fn resolved(&self) -> Result<(), WebhookExecuteError> {
+        let embed = EmbedBuilder::new()
+            .color(0x57F287)
+            .description("Every request was successful.");
+        self.execute_embed_webhook(embed.build()).await
+    }
+
+    pub async fn execute_embed_webhook(&self, embed: Embed) -> Result<(), WebhookExecuteError> {
         self.discord_client
             .execute_webhook(self.id, &self.token)
             .embeds(&[embed])?


### PR DESCRIPTION
This PR changes the behavior of sending an alert into our alert channel. It is done by only sending an alert when a request failed and then only again when all requests went through. Also it groups multiple fails into one alert message.